### PR TITLE
fix minorticklocator being None for mpl >= 3.6.0

### DIFF
--- a/proplot/axes/base.py
+++ b/proplot/axes/base.py
@@ -1140,6 +1140,12 @@ class Axes(maxes.Axes):
             elif isinstance(ticker, mticker.TickHelper):
                 ticker.set_axis(axis)
 
+        if _version_mpl >= '3.6':
+            print("minorlocator is None, mpl >= 3.6 fix set it to MultipleLocator")
+            if minorlocator is None:
+                from matplotlib.ticker import AutoLocator
+                minorlocator = AutoLocator()
+
         # Create colorbar and update ticks and axis direction
         # NOTE: This also adds the guides._update_ticks() monkey patch that triggers
         # updates to DiscreteLocator when parent axes is drawn.


### PR DESCRIPTION
If `minorlocator is None` `mpl > 3.6.0` crashes when adding a colorbar with
```python
TypeError: 'locator' must be an instance of matplotlib.ticker.Locator, not a None
```
I fix this by setting `minorlocator = AutoLocator()` if `minorlocator is None`

A MWE that crashes below
```python
import matplotlib
import proplot as pplt
import numpy as np

matplotlib.use("Agg")
pplt.rc["cmap.sequential"] = "viridis"

state = np.random.RandomState(51423)
fig = pplt.figure()

# Colorbars
ax = fig.subplot(121, title="Axes colorbars")
data = state.rand(10, 10)
m = ax.heatmap(data, cmap="dusk")
ax.colorbar(m, loc="r", cmap="viridis")
```